### PR TITLE
LPS-56357 fix paste plugin width in dialog when drag the dialog.

### DIFF
--- a/plugins/clipboard/dialogs/paste.js
+++ b/plugins/clipboard/dialogs/paste.js
@@ -93,12 +93,12 @@ CKEDITOR.dialog.add( 'paste', function( editor ) {
 				{
 				type: 'html',
 				id: 'securityMsg',
-				html: '<div style="white-space:normal;width:340px">' + lang.securityMsg + '</div>'
+				html: '<div style="white-space:normal;width:100%">' + lang.securityMsg + '</div>'
 			},
 				{
 				type: 'html',
 				id: 'pasteMsg',
-				html: '<div style="white-space:normal;width:340px">' + lang.pasteMsg + '</div>'
+				html: '<div style="white-space:normal;width:100%">' + lang.pasteMsg + '</div>'
 			},
 				{
 				type: 'html',

--- a/skins/kama/dialog.css
+++ b/skins/kama/dialog.css
@@ -697,7 +697,7 @@ tendency that these will be moved to the plugins code in the future.
 
 .cke_dialog iframe.cke_pasteframe
 {
-	width: 346px;
+	width: 100%;
 	height: 130px;
 	background-color: white;
 	border: 1px solid black;

--- a/skins/moono/dialog.css
+++ b/skins/moono/dialog.css
@@ -945,7 +945,7 @@ tendency that these will be moved to the plugins code in the future.
 
 .cke_dialog iframe.cke_pasteframe
 {
-	width: 346px;
+	width: 100%;
 	height: 130px;
 	background-color: white;
 	border: 1px solid #aeb3b9;


### PR DESCRIPTION
Hi Byrån,

The issue belongs to ckeditor issue. I can reproduce the issue on ckeditor demo. For other plugins, for exmaple, link plugin, its width can be adapted with dialog's change.

ckeditor demo: http://ckeditor.com/demo#full

Reproduced Issue: Please refer to reproduced.gif on LPS-56357.
After fixed: Please refer to fixed.gif on LPS-56357.

For the height issue, all ckeditor's plugins have the same issue. I don't find one way to change the height. Should we fix the issue on the height? If possible, could you please help solve it?

Ticket:
https://issues.liferay.com/browse/LPP-16965

Thanks in advance.

Regards,
Hai