### PR TITLE
LPS-56699 Improve Japanese translation for bullet list properties in Ckeditor.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ CKEditor 4 Changelog
 
 Fixed Issues:
 
+* [LPS-55669](https://issues.liferay.com/browse/LPS-56699): Improve Japanese translation for bullet list properties in Ckeditor.
+
 * [LPS-55288](https://issues.liferay.com/browse/LPS-55288): Prevent `toPre()` from converting `<br>` to new-line characters in all but IE<8. Adapted from, [#4711](https://dev.ckeditor.com/ticket/4711), [#9535](https://dev.ckeditor.com/ticket/9535)
 
 ## CKEditor 4.4.5

--- a/plugins/liststyle/lang/ja.js
+++ b/plugins/liststyle/lang/ja.js
@@ -14,7 +14,7 @@ CKEDITOR.plugins.setLang( 'liststyle', 'ja', {
 	lowerGreek: '小文字ギリシャ文字 (alpha, beta, gamma, etc.)',
 	lowerRoman: '小文字ローマ数字 (i, ii, iii, iv, v, etc.)',
 	none: 'なし',
-	notset: '<なし>',
+	notset: '<指定なし>',
 	numberedTitle: '番号付きリストのプロパティ',
 	square: '四角',
 	start: '開始',


### PR DESCRIPTION
Hey Byran.

This is such a minor change as it just improves a Japanese translation.

I think we can do a favour to our Japanese customer for correcting this translation, without involving ckeditor team since it will not affect any functionalities.

Let me know your concerns

Backport: https://github.com/blzaugg/liferay-ckeditor/pull/5

Thanks
John.