### PR TITLE
LPS- 57040 [TECHNICAL SUPPORT] Japanese input conversion is auto-confirmed randomly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,9 @@
 CKEditor 4 Changelog
 ====================
 
-CKEditor 4.0.3-r19
+## CKEditor 4.0.3-r19
 
-* [#10042](https://dev.ckeditor.com/ticket/10042): Allow setting meaningful title for inline editable element
+* [#LPS-56987](https://issues.liferay.com/browse/LPS-56987): Backport [#10042](https://dev.ckeditor.com/ticket/10042): Allow setting meaningful title for inline editable element
 
 ## CKEditor 4.0.3-r18
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 CKEditor 4 Changelog
 ====================
+
+CKEditor 4.0.3-r19
+
+* [#10042](https://dev.ckeditor.com/ticket/10042): Allow setting meaningful title for inline editable element
+
 ## CKEditor 4.0.3-r18
 
 * [LPS-56699](https://issues.liferay.com/browse/LPS-56699): Improve Japanese translation for bullet list properties in Ckeditor.

--- a/core/editable.js
+++ b/core/editable.js
@@ -960,11 +960,13 @@
 			// editable is instead handled by plugin.
 			if ( editable && editable.isInline() ) {
 
-				var ariaLabel = this.lang.editor + ', ' + this.name;
+				var ariaLabel = editor.title;
 
 				editable.changeAttr( 'role', 'textbox' );
 				editable.changeAttr( 'aria-label', ariaLabel );
-				editable.changeAttr( 'title', ariaLabel );
+
+				if ( ariaLabel )
+					editable.changeAttr( 'title', ariaLabel );
 
 				// Put the voice label in different spaces, depending on element mode, so
 				// the DOM element get auto detached on mode reload or editor destroy.

--- a/core/editor.js
+++ b/core/editor.js
@@ -336,6 +336,8 @@
 
 	function loadLang( editor ) {
 		CKEDITOR.lang.load( editor.config.language, editor.config.defaultLanguage, function( languageCode, lang ) {
+			var configTitle = editor.config.title;
+
 			/**
 			 * The code for the language resources that have been loaded
 			 * for the user interface elements of this editor instance.
@@ -357,6 +359,20 @@
 			// from different language code files, we need a copy of lang,
 			// not a direct reference to it.
 			editor.lang = CKEDITOR.tools.prototypedCopy( lang );
+
+			/**
+			 * Indicates the human-readable title of this editor. Although this is a read-only property,
+			 * it can be initialized with {@link CKEDITOR.config#title}.
+			 *
+			 * **Note:** Please don't confuse this property with {@link CKEDITOR.editor#name editor.name}
+			 * which identifies the instance in {@link CKEDITOR#instances} literal.
+			 *
+			 * @since 4.2
+			 * @readonly
+			 * @property {String/Boolean}
+			 */
+			editor.title = typeof configTitle == 'string' || configTitle === false ? configTitle : [ editor.lang.editor, editor.name ].join( ', ' );
+
 
 			// We're not able to support RTL in Firefox 2 at this time.
 			if ( CKEDITOR.env.gecko && CKEDITOR.env.version < 10900 && editor.lang.dir == 'rtl' )
@@ -1010,6 +1026,35 @@ CKEDITOR.ELEMENT_MODE_INLINE = 3;
  *
  * @cfg {Boolean} [startupFocus=false]
  * @member CKEDITOR.config
+ */
+
+/**
+ * Customizes the {@link CKEDITOR.editor#title human-readable title} of this editor. This title is displayed in
+ * tooltips and impacts on various accessibility aspects, e.g. it is commonly used by screen readers
+ * for distinguishing editor instances and for navigation. Accepted values are string or `false`.
+ *
+ * **Note:** When `config.title` set globally, the same value will be applied to all editor instances
+ * loaded with this config. This may have a critical impact on several accessibility aspects.
+ *
+ * **Note:** Setting `config.title = false` may also have a critical impact on
+ * several accessibility aspects.
+ *
+ * **Note:** Please don't confuse this property with {@link CKEDITOR.editor#name}
+ * which identifies the instance in {@link CKEDITOR#instances} literal.
+ *
+ *		// Set title to 'My WYSIWYG editor.'. The original title of the element (if any)
+ *		// will be restored once the editor instance is destroyed.
+ *		config.title = 'My WYSIWYG editor.';
+ *
+ *		// Don't touch the title. If the element already has a title, it remains untouched.
+ *		// Also if there is no title attribute, nothing new will be added.
+ *		config.title = false;
+ *
+ * @since 4.2
+ * @cfg {String/Boolean} [title=based on editor.name]
+ * @member CKEDITOR.config
+ * @see CKEDITOR.editor.name
+ * @see CKEDITOR.editor.title
  */
 
 /**

--- a/dev/builder/build.sh
+++ b/dev/builder/build.sh
@@ -70,7 +70,7 @@ else
 fi
 
 CKEDITOR_VERSION="4.0.3"
-CKEDITOR_REVISION="18"
+CKEDITOR_REVISION="19"
 
 java -jar ckbuilder/$CKBUILDER_VERSION/ckbuilder.jar --build ../../ release --version $CKEDITOR_VERSION --revision $CKEDITOR_REVISION --build-config build-config.js --overwrite --no-tar --no-zip $DEV_OPS
 

--- a/plugins/undo/plugin.js
+++ b/plugins/undo/plugin.js
@@ -66,10 +66,18 @@
 			// Registering keydown on every document recreation.(#3844)
 			editor.on( 'contentDom', function() {
 				editor.editable().on( 'keydown', function( event ) {
-					// Do not capture CTRL hotkeys.
-					if ( !event.data.$.ctrlKey && !event.data.$.metaKey )
-						undoManager.type( event );
+					var keystroke = event && event.data.getKey();
+
+					if (keystroke == 8/*Backspace*/ || keystroke == 46/*Delete*/ ) {
+						undoManager.type( keystroke, false );
+					}
 				});
+
+				editor.editable().on( 'keypress', function( event ) {
+					var keystroke = event && event.data.getKey();
+					undoManager.type( keystroke, true );
+				});
+
 			});
 
 			// Always save an undo snapshot - the previous mode might have
@@ -227,9 +235,6 @@
 
 			return true;
 		},
-		equals: function( otherImage ) {
-			return this.equalsContent( otherImage ) && this.equalsSelection( otherImage );
-		}
 	};
 
 	/**
@@ -249,12 +254,6 @@
 		this.reset();
 	}
 
-	/* keyTypes:
-		-1: delete (Backspace, Delete),
-		 0: neutral (Home, F1, Shift),
-		 1: character (a, 9, &) */
-	var keyTypes = { 8: -1/*Backspace*/, 9: 0/*Tab*/, 13: 1/*Enter*/, 16: 0/*Shift*/, 17: 0/*Ctrl*/, 18: 0/*Alt*/, 19: 0/*Pause/Break*/, 20: 0/*Caps Lock*/, 27: 0/*Esc*/, 32: 1/*Space*/, 33: 0/*Page Up*/, 34: 0/*Page Down*/, 35: 0/*End*/, 36: 0/*Home*/, 37: 0/*Left*/, 38: 0/*Up*/, 39: 0/*Right*/, 40: 0/*Down*/, 45: 0/*Insert*/, 46: -1/*Delete*/, 48: 1/*0*/, 49: 1/*1*/, 50: 1/*2*/, 51: 1/*3*/, 52: 1/*4*/, 53: 1/*5*/, 54: 1/*6*/, 55: 1/*7*/, 56: 1/*8*/, 57: 1/*9*/, 65: 1/*A*/, 66: 1/*B*/, 67: 1/*C*/, 68: 1/*D*/, 69: 1/*E*/, 70: 1/*F*/, 71: 1/*G*/, 72: 1/*H*/, 73: 1/*I*/, 74: 1/*J*/, 75: 1/*K*/, 76: 1/*L*/, 77: 1/*M*/, 78: 1/*N*/, 79: 1/*O*/, 80: 1/*P*/, 81: 1/*Q*/, 82: 1/*R*/, 83: 1/*S*/, 84: 1/*T*/, 85: 1/*U*/, 86: 1/*V*/, 87: 1/*W*/, 88: 1/*X*/, 89: 1/*Y*/, 90: 1/*Z*/, 91: 0/*Windows*/, 93: 0/*Right Click*/, 96: 1/*Numpad 0*/, 97: 1/*Numpad 1*/, 98: 1/*Numpad 2*/, 99: 1/*Numpad 3*/, 100: 1/*Numpad 4*/, 101: 1/*Numpad 5*/, 102: 1/*Numpad 6*/, 103: 1/*Numpad 7*/, 104: 1/*Numpad 8*/, 105: 1/*Numpad 9*/, 106: 1/*Numpad **/, 107: 1/*Numpad +*/, 109: 1/*Numpad -*/, 110: 1/*Numpad .*/, 111: 1/*Numpad /*/, 112: 0/*F1*/, 113: 0/*F2*/, 114: 0/*F3*/, 115: 0/*F4*/, 116: 0/*F5*/, 117: 0/*F6*/, 118: 0/*F7*/, 119: 0/*F8*/, 120: 0/*F9*/, 121: 0/*F10*/, 122: 0/*F11*/, 123: 0/*F12*/, 144: 0/*Num Lock*/, 145: 0/*Scroll Lock*/, 182: 0/*My Computer*/, 183: 0/*My Calculator*/, 186: 1/*;*/, 187: 1/*=*/, 188: 1/*,*/, 189: 1/*-*/, 190: 1/*.*/, 191: 1/*/*/, 192: 1/*`*/, 219: 1/*[*/, 220: 1/*\\*/, 221: 1/*]*/, 222: 1/***/ };
-
 	UndoManager.prototype = {
 		/**
 		 * When `locked` property is not `null` manager is locked, so
@@ -268,26 +267,17 @@
 
 		/**
 		 * Process undo system regard keystrikes.
-		 * @param {CKEDITOR.dom.event} event
+		 * @param {number} keystroke key code,
+		 * @param {boolean} isCharacter if true it is character ('a', '1', '&', ...), otherwise it is remove key (delete or backspace),
 		 */
-		type: function( event ) {
-			var keystroke = event && event.data.getKey(),
-				keyType = keystroke in keyTypes? keyTypes[ keystroke ]:0,
-				isDeleteKey = keyType == -1,
-				isNeutralKey = keyType == 0,
-				isCharacterKey = keyType == 1,
-				lastKeyType = keystroke in keyTypes? keyTypes[ keystroke ]:0,
-				wasDeleteKey = lastKeyType == -1,
-				wasNeutralKey = lastKeyType == 0,
-				sameAsLastEditingKey = isDeleteKey && keystroke == this.lastKeystroke,
-
-				// Create undo snap for every different modifier key.
-				modifierSnapshot = ( isDeleteKey && !sameAsLastEditingKey ),
+		type: function( keystroke, isCharacter ) {
+			var // Create undo snap for every different modifier key.
+				modifierSnapshot = ( !isCharacter && keystroke != this.lastKeystroke ),
 				// Create undo snap on the following cases:
 				// 1. Just start to type .
 				// 2. Typing some content after a modifier.
 				// 3. Typing some content after make a visible selection.
-				startedTyping = !( isNeutralKey || this.typing ) || ( isCharacterKey && ( wasDeleteKey || wasNeutralKey ) ),
+				startedTyping = !this.typing || ( isCharacter && !this.wasCharacter ),
 				editor = this.editor;
 
 			if ( startedTyping || modifierSnapshot ) {
@@ -327,9 +317,10 @@
 			}
 
 			this.lastKeystroke = keystroke;
+			this.wasCharacter = isCharacter;
 
 			// Create undo snap after typed too much (over 25 times).
-			if ( isDeleteKey ) {
+			if ( !isCharacter ) {
 				this.typesCount = 0;
 				this.modifiersCount++;
 
@@ -341,7 +332,7 @@
 						editor.fire( 'change' );
 					}, 0 );
 				}
-			} else if ( isCharacterKey ) {
+			} else {
 				this.modifiersCount = 0;
 				this.typesCount++;
 
@@ -422,11 +413,12 @@
 
 			// Check if this is a duplicate. In such case, do nothing.
 			if ( this.currentImage ) {
-				var equalContent = image.equalsContent( this.currentImage ),
-				    equalSelection = image.equalsSelection( this.currentImage );
+				var equalContent = image.equalsContent( this.currentImage );
 
 				if ( equalContent )
 					return false;
+
+				var equalSelection = image.equalsSelection( this.currentImage );
 
 				this.editor.fire( 'change' );
 

--- a/plugins/undo/plugin.js
+++ b/plugins/undo/plugin.js
@@ -249,9 +249,11 @@
 		this.reset();
 	}
 
-	var editingKeyCodes = { /*Backspace*/8:1,/*Delete*/46:1 },
-		modifierKeyCodes = { /*Shift*/16:1,/*Ctrl*/17:1,/*Alt*/18:1 },
-		navigationKeyCodes = { 37:1,38:1,39:1,40:1 }; // Arrows: L, T, R, B
+	/* keyTypes:
+		-1: delete (Backspace, Delete),
+		 0: neutral (Home, F1, Shift),
+		 1: character (a, 9, &) */
+	var keyTypes = { 8: -1/*Backspace*/, 9: 0/*Tab*/, 13: 1/*Enter*/, 16: 0/*Shift*/, 17: 0/*Ctrl*/, 18: 0/*Alt*/, 19: 0/*Pause/Break*/, 20: 0/*Caps Lock*/, 27: 0/*Esc*/, 32: 1/*Space*/, 33: 0/*Page Up*/, 34: 0/*Page Down*/, 35: 0/*End*/, 36: 0/*Home*/, 37: 0/*Left*/, 38: 0/*Up*/, 39: 0/*Right*/, 40: 0/*Down*/, 45: 0/*Insert*/, 46: -1/*Delete*/, 48: 1/*0*/, 49: 1/*1*/, 50: 1/*2*/, 51: 1/*3*/, 52: 1/*4*/, 53: 1/*5*/, 54: 1/*6*/, 55: 1/*7*/, 56: 1/*8*/, 57: 1/*9*/, 65: 1/*A*/, 66: 1/*B*/, 67: 1/*C*/, 68: 1/*D*/, 69: 1/*E*/, 70: 1/*F*/, 71: 1/*G*/, 72: 1/*H*/, 73: 1/*I*/, 74: 1/*J*/, 75: 1/*K*/, 76: 1/*L*/, 77: 1/*M*/, 78: 1/*N*/, 79: 1/*O*/, 80: 1/*P*/, 81: 1/*Q*/, 82: 1/*R*/, 83: 1/*S*/, 84: 1/*T*/, 85: 1/*U*/, 86: 1/*V*/, 87: 1/*W*/, 88: 1/*X*/, 89: 1/*Y*/, 90: 1/*Z*/, 91: 0/*Windows*/, 93: 0/*Right Click*/, 96: 1/*Numpad 0*/, 97: 1/*Numpad 1*/, 98: 1/*Numpad 2*/, 99: 1/*Numpad 3*/, 100: 1/*Numpad 4*/, 101: 1/*Numpad 5*/, 102: 1/*Numpad 6*/, 103: 1/*Numpad 7*/, 104: 1/*Numpad 8*/, 105: 1/*Numpad 9*/, 106: 1/*Numpad **/, 107: 1/*Numpad +*/, 109: 1/*Numpad -*/, 110: 1/*Numpad .*/, 111: 1/*Numpad /*/, 112: 0/*F1*/, 113: 0/*F2*/, 114: 0/*F3*/, 115: 0/*F4*/, 116: 0/*F5*/, 117: 0/*F6*/, 118: 0/*F7*/, 119: 0/*F8*/, 120: 0/*F9*/, 121: 0/*F10*/, 122: 0/*F11*/, 123: 0/*F12*/, 144: 0/*Num Lock*/, 145: 0/*Scroll Lock*/, 182: 0/*My Computer*/, 183: 0/*My Calculator*/, 186: 1/*;*/, 187: 1/*=*/, 188: 1/*,*/, 189: 1/*-*/, 190: 1/*.*/, 191: 1/*/*/, 192: 1/*`*/, 219: 1/*[*/, 220: 1/*\\*/, 221: 1/*]*/, 222: 1/***/ };
 
 	UndoManager.prototype = {
 		/**
@@ -270,24 +272,23 @@
 		 */
 		type: function( event ) {
 			var keystroke = event && event.data.getKey(),
-				isModifierKey = keystroke in modifierKeyCodes,
-				isEditingKey = keystroke in editingKeyCodes,
-				wasEditingKey = this.lastKeystroke in editingKeyCodes,
-				sameAsLastEditingKey = isEditingKey && keystroke == this.lastKeystroke,
-				// Keystrokes which navigation through contents.
-				isReset = keystroke in navigationKeyCodes,
-				wasReset = this.lastKeystroke in navigationKeyCodes,
-
-				// Keystrokes which just introduce new contents.
-				isContent = ( !isEditingKey && !isReset ),
+				keyType = keystroke in keyTypes? keyTypes[ keystroke ]:0,
+				isDeleteKey = keyType == -1,
+				isNeutralKey = keyType == 0,
+				isCharacterKey = keyType == 1,
+				lastKeyType = keystroke in keyTypes? keyTypes[ keystroke ]:0,
+				wasDeleteKey = lastKeyType == -1,
+				wasNeutralKey = lastKeyType == 0,
+				sameAsLastEditingKey = isDeleteKey && keystroke == this.lastKeystroke,
 
 				// Create undo snap for every different modifier key.
-				modifierSnapshot = ( isEditingKey && !sameAsLastEditingKey ),
+				modifierSnapshot = ( isDeleteKey && !sameAsLastEditingKey ),
 				// Create undo snap on the following cases:
 				// 1. Just start to type .
 				// 2. Typing some content after a modifier.
 				// 3. Typing some content after make a visible selection.
-				startedTyping = !( isModifierKey || this.typing ) || ( isContent && ( wasEditingKey || wasReset ) );
+				startedTyping = !( isNeutralKey || this.typing ) || ( isCharacterKey && ( wasDeleteKey || wasNeutralKey ) ),
+				editor = this.editor;
 
 			if ( startedTyping || modifierSnapshot ) {
 				var beforeTypeImage = new Image( this.editor ),
@@ -328,21 +329,29 @@
 			this.lastKeystroke = keystroke;
 
 			// Create undo snap after typed too much (over 25 times).
-			if ( isEditingKey ) {
+			if ( isDeleteKey ) {
 				this.typesCount = 0;
 				this.modifiersCount++;
 
 				if ( this.modifiersCount > 25 ) {
 					this.save( false, null, false );
 					this.modifiersCount = 1;
+				} else {
+					setTimeout(function() {
+						editor.fire( 'change' );
+					}, 0 );
 				}
-			} else if ( !isReset ) {
+			} else if ( isCharacterKey ) {
 				this.modifiersCount = 0;
 				this.typesCount++;
 
 				if ( this.typesCount > 25 ) {
 					this.save( false, null, false );
 					this.typesCount = 1;
+				} else {
+					setTimeout(function() {
+						editor.fire( 'change' );
+					}, 0 );
 				}
 			}
 
@@ -419,11 +428,11 @@
 				if ( equalContent )
 					return false;
 
+				this.editor.fire( 'change' );
+
 				if ( !onContentOnly && equalContent && equalSelection )
 					return false;
 			}
-
-
 
 			// Drop future snapshots.
 			snapshots.splice( this.index + 1, snapshots.length - this.index - 1 );
@@ -480,6 +489,8 @@
 			// the original snapshot due to dom change. (#4622)
 			this.update();
 			this.fireChange();
+
+			editor.fire( 'change' );
 		},
 
 		// Get the closest available image.

--- a/plugins/undo/plugin.js
+++ b/plugins/undo/plugin.js
@@ -414,18 +414,16 @@
 
 			// Check if this is a duplicate. In such case, do nothing.
 			if ( this.currentImage ) {
-				var equalContent = image.equalsContent( this.currentImage );
-
-				if ( equalContent )
-					return false;
-
-				var equalSelection = image.equalsSelection( this.currentImage );
-
-				this.editor.fire( 'change' );
-
-				if ( !onContentOnly && equalContent && equalSelection )
+				if ( image.equalsContent( this.currentImage ) ) {
+					if ( onContentOnly )
 						return false;
+
+					if ( image.equalsSelection( this.currentImage ) )
+						return false;
+				} else {
+					this.editor.fire( 'change' );
 				}
+			}
 
 			// Drop future snapshots.
 			snapshots.splice( this.index + 1, snapshots.length - this.index - 1 );

--- a/plugins/undo/plugin.js
+++ b/plugins/undo/plugin.js
@@ -574,14 +574,14 @@
 		 */
 		lock: function() {
 			if ( !this.locked ) {
-				var snapBefore = this.editor.getSnapshot();
+				var imageBefore = new Image( this.editor );
 
 				// If current editor content matches the tip of snapshot stack,
 				// the stack tip must be updated by unlock, to include any changes made
 				// during this period.
-				var matchedTip = this.currentImage && snapBefore == this.currentImage.contents;
+				var matchedTip = this.currentImage && this.currentImage.equals( imageBefore, true );
 
-				this.locked = { update: matchedTip ? snapBefore : null, level: 1 };
+				this.locked = { update: matchedTip ? imageBefore : null, level: 1 };
 			}
 			// Increase the level of lock.
 			else
@@ -599,12 +599,11 @@
 			if ( this.locked ) {
 				// Decrease level of lock and check if equals 0, what means that undoM is completely unlocked.
 				if ( !--this.locked.level ) {
-					var update = this.locked.update,
-						snap = this.editor.getSnapshot();
+					var updateImage = this.locked.update;
 
 					this.locked = null;
 
-					if ( typeof update == 'string' && snap != update )
+					if ( updateImage && !updateImage.equals( new Image( this.editor ), true ) )
 						this.update();
 				}
 			}

--- a/plugins/undo/plugin.js
+++ b/plugins/undo/plugin.js
@@ -668,3 +668,16 @@
  * @param {CKEDITOR.editor} editor This editor instance.
  * @see CKEDITOR.editor#beforeUndoImage
  */
+
+/**
+ * Fired when content of editor changed. Change event is part of undo plugin
+ * and will not be fired without this plugin. To make this event fast it is
+ * is not verified if content really changed. In some cases you can get multiple
+ * change events during one change. If it is important not to get change event
+ * too often you should check if content changes after this event.
+ *
+ * @since 4.2
+ * @event change
+ * @member CKEDITOR.editor
+ * @param {CKEDITOR.editor} editor This editor instance.
+ */

--- a/plugins/undo/plugin.js
+++ b/plugins/undo/plugin.js
@@ -192,8 +192,7 @@
 	var protectedAttrs = /\b(?:href|src|name)="[^"]*?"/gi;
 
 	Image.prototype = {
-		equals: function( otherImage, contentOnly ) {
-
+		equalsContent: function( otherImage ) {
 			var thisContents = this.contents,
 				otherContents = otherImage.contents;
 
@@ -206,9 +205,9 @@
 			if ( thisContents != otherContents )
 				return false;
 
-			if ( contentOnly )
-				return true;
-
+			return true;
+		},
+		equalsSelection: function( otherImage ) {
 			var bookmarksA = this.bookmarks,
 				bookmarksB = otherImage.bookmarks;
 
@@ -227,6 +226,9 @@
 			}
 
 			return true;
+		},
+		equals: function( otherImage ) {
+			return this.equalsContent( otherImage ) && this.equalsSelection( otherImage );
 		}
 	};
 
@@ -410,8 +412,18 @@
 				return false;
 
 			// Check if this is a duplicate. In such case, do nothing.
-			if ( this.currentImage && image.equals( this.currentImage, onContentOnly ) )
-				return false;
+			if ( this.currentImage ) {
+				var equalContent = image.equalsContent( this.currentImage ),
+				    equalSelection = image.equalsSelection( this.currentImage );
+
+				if ( equalContent )
+					return false;
+
+				if ( !onContentOnly && equalContent && equalSelection )
+					return false;
+			}
+
+
 
 			// Drop future snapshots.
 			snapshots.splice( this.index + 1, snapshots.length - this.index - 1 );
@@ -480,7 +492,7 @@
 				if ( isUndo ) {
 					for ( i = this.index - 1; i >= 0; i-- ) {
 						image = snapshots[ i ];
-						if ( !currentImage.equals( image, true ) ) {
+						if ( !currentImage.equalsContent( image ) ) {
 							image.index = i;
 							return image;
 						}
@@ -488,7 +500,7 @@
 				} else {
 					for ( i = this.index + 1; i < snapshots.length; i++ ) {
 						image = snapshots[ i ];
-						if ( !currentImage.equals( image, true ) ) {
+						if ( !currentImage.equalsContent( image ) ) {
 							image.index = i;
 							return image;
 						}
@@ -579,7 +591,7 @@
 				// If current editor content matches the tip of snapshot stack,
 				// the stack tip must be updated by unlock, to include any changes made
 				// during this period.
-				var matchedTip = this.currentImage && this.currentImage.equals( imageBefore, true );
+				var matchedTip = this.currentImage && this.currentImage.equalsContent( imageBefore );
 
 				this.locked = { update: matchedTip ? imageBefore : null, level: 1 };
 			}
@@ -603,7 +615,7 @@
 
 					this.locked = null;
 
-					if ( updateImage && !updateImage.equals( new Image( this.editor ), true ) )
+					if ( updateImage && !updateImage.equalsContent( new Image( this.editor ) ) )
 						this.update();
 				}
 			}

--- a/plugins/undo/plugin.js
+++ b/plugins/undo/plugin.js
@@ -66,18 +66,16 @@
 			// Registering keydown on every document recreation.(#3844)
 			editor.on( 'contentDom', function() {
 				editor.editable().on( 'keydown', function( event ) {
-					var keystroke = event && event.data.getKey();
+					var keystroke = event.data.getKey();
 
-					if (keystroke == 8/*Backspace*/ || keystroke == 46/*Delete*/ ) {
-						undoManager.type( keystroke, false );
+					if ( keystroke == 8 /*Backspace*/ || keystroke == 46 /*Delete*/ ) {
+						undoManager.type( keystroke, 0 );
 					}
 				});
 
 				editor.editable().on( 'keypress', function( event ) {
-					var keystroke = event && event.data.getKey();
-					undoManager.type( keystroke, true );
+					undoManager.type( event.data.getKey(), 1 );
 				});
-
 			});
 
 			// Always save an undo snapshot - the previous mode might have
@@ -215,6 +213,7 @@
 
 			return true;
 		},
+
 		equalsSelection: function( otherImage ) {
 			var bookmarksA = this.bookmarks,
 				bookmarksB = otherImage.bookmarks;
@@ -234,7 +233,7 @@
 			}
 
 			return true;
-		},
+		}
 	};
 
 	/**
@@ -267,27 +266,29 @@
 
 		/**
 		 * Process undo system regard keystrikes.
-		 * @param {number} keystroke key code,
-		 * @param {boolean} isCharacter if true it is character ('a', '1', '&', ...), otherwise it is remove key (delete or backspace),
+		 * @param {number} keystroke The key code,
+		 * @param {boolean} isCharacter If true it is character ('a', '1', '&', ...), otherwise it is remove key (delete or backspace),
 		 */
 		type: function( keystroke, isCharacter ) {
-			var // Create undo snap for every different modifier key.
-				modifierSnapshot = ( !isCharacter && keystroke != this.lastKeystroke ),
-				// Create undo snap on the following cases:
-				// 1. Just start to type .
-				// 2. Typing some content after a modifier.
-				// 3. Typing some content after make a visible selection.
-				startedTyping = !this.typing || ( isCharacter && !this.wasCharacter ),
-				editor = this.editor;
+			// Create undo snap for every different modifier key.
+			var modifierSnapshot = ( !isCharacter && keystroke != this.lastKeystroke );
+
+			// Create undo snap on the following cases:
+			// 1. Just start to type .
+			// 2. Typing some content after a modifier.
+			// 3. Typing some content after make a visible selection.
+			var startedTyping = !this.typing || ( isCharacter && !this.wasCharacter );
+
+			var editor = this.editor;
 
 			if ( startedTyping || modifierSnapshot ) {
-				var beforeTypeImage = new Image( this.editor ),
+				var beforeTypeImage = new Image( editor ),
 					beforeTypeCount = this.snapshots.length;
 
 				// Use setTimeout, so we give the necessary time to the
 				// browser to insert the character into the DOM.
 				CKEDITOR.tools.setTimeout( function() {
-					var currentSnapshot = this.editor.getSnapshot();
+					var currentSnapshot = editor.getSnapshot();
 
 					// In IE, we need to remove the expando attributes.
 					if ( CKEDITOR.env.ie )
@@ -423,8 +424,8 @@
 				this.editor.fire( 'change' );
 
 				if ( !onContentOnly && equalContent && equalSelection )
-					return false;
-			}
+						return false;
+				}
 
 			// Drop future snapshots.
 			snapshots.splice( this.index + 1, snapshots.length - this.index - 1 );
@@ -670,11 +671,15 @@
  */
 
 /**
- * Fired when content of editor changed. Change event is part of undo plugin
- * and will not be fired without this plugin. To make this event fast it is
- * is not verified if content really changed. In some cases you can get multiple
- * change events during one change. If it is important not to get change event
- * too often you should check if content changes after this event.
+ * Fired when the content of the editor changed.
+ *
+ * Due to performance reasons, it is not verified if the content really changed.
+ * The editor instead watches several editing actions that usually result on
+ * changes. Therefore, this event may be fired when no changes happen on some
+ * cases or even get fired twice.
+ *
+ * If it is important not to get change event too often you should compare the
+ * previous and the current editor content inside the event listener.
  *
  * @since 4.2
  * @event change

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -38,11 +38,15 @@
 				if ( useOnloadEvent )
 					iframe.on( 'load', onLoad );
 
-				var frameLabel = [ editor.lang.editor, editor.name ].join( ',' ),
+				var frameLabel = editor.title,
 					frameDesc = editor.lang.common.editorHelp;
 
-				if ( CKEDITOR.env.ie )
-					frameLabel += ', ' + frameDesc;
+				if ( frameLabel ) {
+					if ( CKEDITOR.env.ie )
+						frameLabel += ', ' + frameDesc;
+
+					iframe.setAttribute( 'title', frameLabel );
+				}
 
 				var labelId = CKEDITOR.tools.getNextId(),
 					desc = CKEDITOR.dom.element.createFromHtml( '<span id="' + labelId + '" class="cke_voice_label">' + frameDesc + '</span>' );
@@ -58,7 +62,6 @@
 				iframe.setAttributes({
 					frameBorder: 0,
 					'aria-describedby' : labelId,
-					title: frameLabel,
 					src: src,
 					tabIndex: editor.tabIndex,
 					allowTransparency: 'true'


### PR DESCRIPTION
Hi Byrån, @daledotshan, @hhuijser

The issue explanation is as the following:

The issue can't be reproduced on ee-4.4.x.
In ckeditor_4.1.3, the issue can be reproduced.
In 4.2 ( 2013.07.18), the issue can't be reproduced. So I think the issue was fixed in 4.2. 

I checked 4.2 fix and try to use the current fix commit and it can solve the issue

The issue was fixed in http://dev.ckeditor.com/ticket/9794. I backport the related commit so that I don't merge any conflict. The previous two commits are not fix in 9794. But 9794's fix was based on the two commits. Please check whether it is right.

Regards,
Hai


