### PR TITLE
LPS-61684 Unable to Paste content in CKEditor

### DIFF
--- a/_source/plugins/clipboard/plugin.js
+++ b/_source/plugins/clipboard/plugin.js
@@ -409,6 +409,12 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
 					// Intercept the paste before it actually takes place.
 					body.on( !CKEDITOR.env.ie ? 'paste' : 'beforepaste', function( evt )
 						{
+							function repeatParagraphs( repeats ) {
+								// Repeat blocks floor((n+1)/2) times.
+								// Even number of repeats - add <br> at the beginning of last <p>.
+								return CKEDITOR.tools.repeat( '</p><p>', ~~ ( repeats / 2 ) ) + ( repeats % 2 == 1 ? '<br>' : '' );
+							}
+
 							if ( depressBeforeEvent )
 								return;
 

--- a/_source/plugins/selection/plugin.js
+++ b/_source/plugins/selection/plugin.js
@@ -278,7 +278,7 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
 						body = doc.getBody(),
 						html = doc.getDocumentElement();
 
-					if ( isMSSelection )
+					if ( CKEDITOR.env.ie )
 					{
 						// Other browsers don't loose the selection if the
 						// editor document loose the focus. In IE, we don't


### PR DESCRIPTION
Hey Byran

In LPS-49073, we backport this fix https://github.com/blzaugg/liferay-ckeditor-old/commit/54e01f34f6f7b862f23946c9df30c72cc91054ef in https://github.com/blzaugg/liferay-ckeditor-old/pull/16.

However, it is not backported correctly with an undefined method repeatParagraphs.

So, we need to add it back.

Thanks
John.